### PR TITLE
installer: add the kubectl binary

### DIFF
--- a/bootstrap/prepare.sh
+++ b/bootstrap/prepare.sh
@@ -537,6 +537,10 @@ if [ "$1" = create ]; then
 
   lokoctl cluster apply --verbose --skip-components
   lokoctl component apply
+  if [ -z "$USE_QEMU" ]; then
+    echo "Setting up ~/.kube/config symlink for kubectl"
+    ln -fs ~/"lokoctl-assets/$(cluster_name)/cluster-assets/auth/kubeconfig" ~/.kube/config
+  fi
   echo "Now you can directly change the baremetal.lokocfg config and run: lokoctl cluster|component apply, this script here is not needed anymore"
 else
   if [ -n "$USE_QEMU" ]; then

--- a/installer/conf.yaml
+++ b/installer/conf.yaml
@@ -10,8 +10,16 @@ modules:
       url: https://releases.hashicorp.com/terraform/0.13.6/terraform_0.13.6_linux_amd64.zip
       sha256: 55f2db00b05675026be9c898bdd3e8230ff0c5c78dd12d743ca38032092abfc9
       dest-filename: terraform.zip
+    - type: file
+      url: https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl
+      sha256: 2583b1c9fbfc5443a722fb04cf0cc83df18e45880a2cf1f6b52d9f595c5beb88
+      dest-filename: kubectl
     - type: git
       url: https://github.com/kinvolk/lokomotive.git
       branch: "kai/baremetal"
     build-commands:
-    - mkdir bin && mv racker bin/ && unzip terraform.zip -d bin/ && rm terraform.zip && cd lokomotive && make && cp lokoctl ../bin/ && cd .. && rm -rf lokomotive
+    - mkdir bin
+    - mv racker bin/
+    - unzip terraform.zip -d bin/ && rm terraform.zip
+    - mv kubectl bin/ && chmod +x bin/kubectl
+    - cd lokomotive && make && cp lokoctl ../bin/ && cd .. && rm -rf lokomotive

--- a/installer/racker-run.sh
+++ b/installer/racker-run.sh
@@ -25,5 +25,6 @@ nsenter -a -t 1 mkdir -p /opt/bin
 nsenter -a -t 1 ln -fs /opt/racker/bin/racker /opt/bin/racker
 nsenter -a -t 1 ln -fs /opt/racker/bin/lokoctl /opt/bin/lokoctl
 nsenter -a -t 1 ln -fs /opt/racker/bin/terraform /opt/bin/terraform
+nsenter -a -t 1 ln -fs /opt/racker/bin/kubectl /opt/bin/kubectl
 
 echo "Installation complete, you may now run: racker"


### PR DESCRIPTION
While lokoctl manages the cluster, the usual interaction is done with
kubectl. This is handy to have around on the management node for
configuration, deployment, and debugging.