### PR TITLE
bootstrap: change matchbox ownership to current user

### DIFF
--- a/bootstrap/prepare.sh
+++ b/bootstrap/prepare.sh
@@ -268,6 +268,7 @@ function create_containers() {
   destroy_containers
 
   sudo mkdir -p "/opt/racker-state/matchbox/groups"
+  sudo chown -R $USER:$USER "/opt/racker-state/matchbox"
   MATCHBOX_CMD="docker run --name matchbox \
     -d \
     --net=host \


### PR DESCRIPTION
While the /opt/racker-state/ folders are used by the containers
running as root this may not be the case for unprivileged containers
with a developer machine and it would shift most actions that the
prepare script does to requiring root access, and we would need to
prefix most commands like downloading Flatcar or copying certs with
"sudo". Thus, give at least initial ownership to the current user
and the matchbox container can later create root-owned files in the
folders as it wants.
