### PR TITLE
bootstrap: support static IP addrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ categorized by their type (HW specs)
 Example `nodes.csv`:
 
 ```
-Primary MAC address, BMC MAC address, Node Type, Comments
-00:11:22:33:44:00, 00:11:22:33:44:01, red, mgmt node # for completeness the management node itself, will be ignored
-00:11:22:33:44:10, 00:11:22:33:44:11, red, controller
-00:11:22:33:44:20, 00:11:22:33:44:21, purple, worker
+Primary MAC address, BMC MAC address, Secondary MAC address, Node Type, Comments
+00:11:22:33:44:00, 00:11:22:33:44:01, 00:11:22:33:44:30, red, mgmt node # for completeness the management node itself, will be ignored
+00:11:22:33:44:10, 00:11:22:33:44:11, 00:11:22:33:44:40, red, controller
+00:11:22:33:44:20, 00:11:22:33:44:21, 00:11:22:33:44:50, purple, worker
 ```
 
 ### Provisioning a Lokomotive Kubernetes cluster

--- a/bootstrap/baremetal.lokocfg
+++ b/bootstrap/baremetal.lokocfg
@@ -16,6 +16,7 @@ cluster "bare-metal" {
   worker_macs = var.worker_macs
   worker_names = var.worker_names
   clc_snippets = { for name, paths in var.clc_snippets : name => [ for path in paths : file(path)] }
+  installer_clc_snippets = { for name, paths in var.installer_clc_snippets : name => [ for path in paths : file(path)] }
   network_ip_autodetection_method = "can-reach=${var.matchbox_addr}"
   kernel_args = ["flatcar.autologin"]
   kernel_console = var.kernel_console
@@ -68,6 +69,10 @@ variable "worker_names" {
 }
 
 variable "clc_snippets" {
+  type = "map(list(string))"
+}
+
+variable "installer_clc_snippets" {
   type = "map(list(string))"
 }
 

--- a/installer/racker
+++ b/installer/racker
@@ -105,6 +105,26 @@ elif [ "$1" = bootstrap ]; then
     sudo systemctl stop locksmithd
   fi
 
+  # testing: use static IP addrs
+  # get sorted nodes without mgmt node
+  NODES="$(tail -n +2 /usr/share/oem/nodes.csv | grep -v -f <(cat /sys/class/net/*/address) | sort)"
+  PUBLIC_IP_ADDRS=""
+  count=110
+  while IFS= read -r line
+  do
+    sec_mac=$(echo "$line" | cut -d , -f 3)
+    ip_addr="172.18.4.${count}"
+    PUBLIC_IP_ADDRS+=" ${sec_mac}-${ip_addr}/22-172.18.4.9-172.18.4.9"
+    let count+=1
+    if [ $count -eq 114 ] || [ $count -eq 115 ]; then
+      let count+=1
+    fi
+    if [ $count -eq 182 ]; then
+       exit 1
+    fi
+  done <<< "$NODES"
+  export PUBLIC_IP_ADDRS
+  #
   ret=0
   USE_QEMU=0 CONTROLLER_AMOUNT=3 CONTROLLER_TYPE=red CLUSTER_NAME=firebox /opt/racker/bootstrap/prepare.sh create || ret=$?
 


### PR DESCRIPTION
In case static IP addresses are used, they should be set up for the
PXE installation process and for the final OS.
Use an additional CLC snippet for static IP addresses, for now only
the most simple case of one static IPv4 address for one MAC address
per node is covered.
For testing purposes the "racker bootstrap" command will generate a
mapping of addresses that we can use in the test setup but it should be
provided by the user. (Need to implement that)
