### PR TITLE
bootstrap: put docker command into unit file to update the image tag

### DIFF
--- a/bootstrap/dnsmasq.service
+++ b/bootstrap/dnsmasq.service
@@ -10,7 +10,7 @@ RestartSec=5s
 TimeoutStartSec=0
 EnvironmentFile=/opt/racker-state/dnsmasq-service
 ExecStartPre=-docker rm -f dnsmasq
-ExecStartPre=sh -c "${DNSMASQ_CMD}"
+ExecStartPre=docker run --name dnsmasq -d --cap-add=NET_ADMIN -v /opt/racker-state/dnsmasq/dnsmasq.conf:/etc/dnsmasq.conf:Z --net=host quay.io/coreos/dnsmasq:v0.5.0 -d
 ExecStart=docker logs -f dnsmasq
 ExecStop=docker stop dnsmasq
 ExecStopPost=docker rm dnsmasq

--- a/bootstrap/matchbox.service
+++ b/bootstrap/matchbox.service
@@ -10,7 +10,7 @@ RestartSec=5s
 TimeoutStartSec=0
 EnvironmentFile=/opt/racker-state/matchbox-service
 ExecStartPre=-docker rm -f matchbox
-ExecStartPre=sh -c "${MATCHBOX_CMD}"
+ExecStartPre=docker run --name matchbox -d --net=host -v /opt/racker-state/matchbox/certs:/etc/matchbox:Z -v /opt/racker-state/matchbox/assets:/var/lib/matchbox/assets:Z -v /opt/racker-state/matchbox:/var/lib/matchbox -v /opt/racker-state/matchbox/groups:/var/lib/matchbox/groups quay.io/coreos/matchbox:v0.7.0 -address=${MATCHBOX_IP_ADDR}:8080 -log-level=debug -rpc-address=${MATCHBOX_IP_ADDR}:8081
 ExecStart=docker logs -f matchbox
 ExecStop=docker stop matchbox
 ExecStopPost=docker rm matchbox


### PR DESCRIPTION
The only external configuration the matchbox.service file needs in the
docker command line is the IP address to bind to, not the full command
line. Separating it makes it possible to update the command line
including the image tag by updating the service file.


