### PR TITLE
bootstrap: do not allow to start unit again if it ran once

### DIFF
--- a/bootstrap/network.yaml.template
+++ b/bootstrap/network.yaml.template
@@ -23,6 +23,7 @@ systemd:
         After=network-online.target
         [Service]
         Type=oneshot
+        RemainAfterExit=yes
         Restart=on-failure
         RestartSec=5s
         ExecStart=docker run --privileged --net host --rm quay.io/kinvolk/racker:{{RACKER_VERSION}} sh -c 'ipmitool chassis bootdev disk options=persistent,efiboot && ipmitool raw 0x00 0x08 0x05 0xe0 0x08 0x00 0x00 0x00'


### PR DESCRIPTION
A oneshot service which terminates can be triggered again by the
target or service that depends on it. This can be prevented by
keeping the service marked as active after it terminated.
This is not a bug fix but rather a precaution.
