### PR TITLE
bootstrap: default to 3 controllers for an HA control plane

### DIFF
--- a/bootstrap/args.yaml
+++ b/bootstrap/args.yaml
@@ -8,12 +8,12 @@ args:
     type: input
 - name: num-controllers
   var: CONTROLLER_AMOUNT
-  default: 1
+  default: 3
   options:
   - 1
   - 3
   prompt:
-    message: Choose the controller amount
+    message: Choose the controller amount, 3 controllers ensure high availability
     type: select
 - name: controller-type
   var: CONTROLLER_TYPE


### PR DESCRIPTION
With three controllers one node can go down and be replaced without
having an impact on the cluster. This is helpful when automatic OS
updates are enabled and a reboot can cause downtime or even cause
the node not to come up again due to unrelated problems.
