### PR TITLE
racker: remove hardcoded IP address assignment, run bootstrap -- -h without having any side effects, racker: quote the elements of the argument list

### DIFF
--- a/installer/racker
+++ b/installer/racker
@@ -110,7 +110,7 @@ elif [ "$1" = bootstrap ]; then
   node_types=$(echo -n "${node_types_list}" | sed 's/^/  - /' | sed 's/$/\\/g' | tr '\n' n | sed 's/\\$//g')
   # Ask for the configuration and save it in a temp file
   ARGS_FILE="$(mktemp)"
-  args-wizard -config <(sed 's/  - ${node_types}'"/${node_types}/g" /opt/racker/bootstrap/args.yaml) > $ARGS_FILE -- ${@:2}
+  args-wizard -config <(sed 's/  - ${node_types}'"/${node_types}/g" /opt/racker/bootstrap/args.yaml) > $ARGS_FILE -- "${@:2}"
   # Exit on -h
   if [ "$(wc -l $ARGS_FILE | cut -d " " -f 1)" = "0" ]; then
     exit 0


### PR DESCRIPTION
-  racker: remove hardcoded IP address assignment
  For testing purposes we had generated the value for the IP address
  setting. Now the wizard asks for it and we can enter it.

- racker: run bootstrap -- -h without having any side effects
    
    If just the wizard help output is shown, there is no need to complain
    about an existing folder or to disable locksmith.

- racker: quote the elements of the argument list
    
    The wizard parameter "-ip-addrs" needs a value with spaces, therefore,
    quote the arguments when passing them through to preserve them.
