### PR TITLE
bootstrap: disable timeout that clears the boot flag, and PXE boot in EFI mode

### DIFF
--- a/bootstrap/network.yaml.template
+++ b/bootstrap/network.yaml.template
@@ -18,7 +18,7 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Workaround to really persist the boot settings because sometimes they get lost. The raw command can be dropped once a new ipmitool version is released that fixes the first command (only one flag works in 1.8.18).
+        Description=Workaround to really persist the boot settings because they get lost when the 60 secs timeout is not disabled. The last raw command can be replaced with ipmitool chassis bootdev disk options=persistent,efiboot once a new ipmitool version is released that fixes the bootdev command (only one flag out of efiboot and persistent works in 1.8.18).
         Requires=network-online.target
         After=network-online.target
         [Service]
@@ -26,7 +26,7 @@ systemd:
         RemainAfterExit=yes
         Restart=on-failure
         RestartSec=5s
-        ExecStart=docker run --privileged --net host --rm quay.io/kinvolk/racker:{{RACKER_VERSION}} sh -c 'ipmitool chassis bootdev disk options=persistent,efiboot && ipmitool raw 0x00 0x08 0x05 0xe0 0x08 0x00 0x00 0x00'
+        ExecStart=docker run --privileged --net host --rm quay.io/kinvolk/racker:{{RACKER_VERSION}} sh -c 'ipmitool raw 0x0 0x8 0x3 0x1f && ipmitool raw 0x00 0x08 0x05 0xe0 0x08 0x00 0x00 0x00'
         [Install]
         WantedBy=multi-user.target
 storage:

--- a/bootstrap/prepare.sh
+++ b/bootstrap/prepare.sh
@@ -449,9 +449,11 @@ EOF
 	pxe_commands = "sudo virt-install --name \$domain --network=bridge:${INTERNAL_BRIDGE_NAME},mac=\$mac  --network=bridge:${EXTERNAL_BRIDGE_NAME} --memory=${VM_MEMORY} --vcpus=1 --disk pool=default,size=${VM_DISK} --os-type=linux --os-variant=generic --noautoconsole --events on_poweroff=preserve --boot=hd,network"
 EOF
   else
+    # The first ipmitool raw command is used to disable the 60 secs timeout that clears the boot flag
+    # The "ipmitool raw 0x00 0x08 0x05 0xe0 0x08 0x00 0x00 0x00" command can be replaced with "ipmitool chassis bootdev disk options=persistent,efiboot" once a new IPMI tool version is released
     tee -a lokocfg.vars <<-EOF
 	kernel_console = ["console=ttyS1,57600n8", "earlyprintk=serial,ttyS1,57600n8"]
-	install_pre_reboot_cmds = "docker run --privileged --net host --rm quay.io/kinvolk/racker:${RACKER_VERSION} sh -c 'ipmitool chassis bootdev disk options=persistent,efiboot && ipmitool raw 0x00 0x08 0x05 0xe0 0x08 0x00 0x00 0x00'"
+	install_pre_reboot_cmds = "docker run --privileged --net host --rm quay.io/kinvolk/racker:${RACKER_VERSION} sh -c 'ipmitool raw 0x0 0x8 0x3 0x1f && ipmitool raw 0x00 0x08 0x05 0xe0 0x08 0x00 0x00 0x00'"
 	pxe_commands = "${SCRIPTFOLDER}/pxe-boot.sh \$mac \$domain"
 EOF
   fi

--- a/bootstrap/pxe-boot.sh
+++ b/bootstrap/pxe-boot.sh
@@ -30,7 +30,7 @@ else
 fi
 bmcipaddr=""
 # poweron must be the last because when the OS comes up it does its own IPMI setup and we also don't know when any step after poweron would be executed
-steps=(bootdev poweroff bootdev poweron)
+steps=(timeroff poweroff bootdev poweron)
 count=60
 while [ $count -gt 0 ]; do
   count=$((count - 1))
@@ -41,7 +41,12 @@ while [ $count -gt 0 ]; do
   if [ "$bmcipaddr" = "" ]; then
     continue
   fi
-  if [ "${steps[0]}" = poweroff ]; then
+  if [ "${steps[0]}" = timeroff ]; then
+    # Disable the 60 sec timeout that clears the boot flag valid bit
+    docker run --privileged --net host --rm quay.io/kinvolk/racker:${RACKER_VERSION} ipmitool -C3 -I lanplus -H $bmcipaddr -U ${IPMI_USER} -P ${IPMI_PASSWORD} raw 0x0 0x8 0x3 0x1f || continue
+    steps=(${steps[*]:1})
+    continue
+  elif [ "${steps[0]}" = poweroff ]; then
     docker run --privileged --net host --rm quay.io/kinvolk/racker:${RACKER_VERSION} ipmitool -C3 -I lanplus -H $bmcipaddr -U ${IPMI_USER} -P ${IPMI_PASSWORD} power off || continue
     steps=(${steps[*]:1})
     continue


### PR DESCRIPTION
- bootstrap: disable timeout that clears the boot flag
    
    By default there is a 60 sec timeout that clears the boot flag valid
    bit and thus prevents the persistent flag to actually take effect.
    
    From the manual:
      23. Setting BMC boot flag valid bit clearing
      ipmitool raw 0x0 0x8 0x3 0x1f – Cancel 60 seconds timeout
      Based on IPMI rule, if the system reset time and system boot time is higher than this default 60
      seconds time out.
      This boot information and boot flag from “ipmitool chassis bootdev xxx” would be cleared by BMC.
      then BIOS can’t get this boot information from BMC. Send the command to cancel the 60 seconds
      timeout.

-  bootstrap: force PXE boot in EFI mode
    
    By default the BIOS mode is set by ipmitool. The switch from EFI to
    BIOS and back can cause troubles we should avoid if not necessary.