### PR TITLE
racker: add parameter to exclude nodes from provisioning

### DIFF
--- a/bootstrap/prepare.sh
+++ b/bootstrap/prepare.sh
@@ -7,6 +7,7 @@ RETRIES=${RETRIES:-"3"} # maximal retries if ONFAILURE=retry
 CLUSTER_NAME=${CLUSTER_NAME:-"lokomotive"}
 CLUSTER_DIR="$PWD"
 ASSET_DIR="${CLUSTER_DIR}/lokoctl-assets"
+EXCLUDE_NODES=(${EXCLUDE_NODES-""}) # white-space separated list of MAC addresses to exclude from provisioning (don't change VAR- to VAR:-)
 PUBLIC_IP_ADDRS="${PUBLIC_IP_ADDRS:-"DHCP"}" # "DHCP" or otherwise an INI-like format with "[SECONDARY_MAC_ADDR]" sections and "ip_addr = IP_V4_ADDR/SUBNETSIZE", "gateway = GATEWAY_ADDR", "dns = DNS_ADDR" entries
 if [ "${PUBLIC_IP_ADDRS}" = "DHCP" ]; then
   # use an empty INI config for no custom IP address configurations
@@ -106,6 +107,11 @@ else
   fi
   # Skip header line, filter out the management node itself and sort by MAC address
   NODES="$(tail -n +2 /usr/share/oem/nodes.csv | grep -v -f <(cat /sys/class/net/*/address) | sort)"
+  if [ "${#EXCLUDE_NODES[*]}" != 0 ]; then
+    for node in ${EXCLUDE_NODES[*]}; do
+      NODES="$(echo "$NODES" | grep -v "${N}")"
+    done
+  fi
   FULL_MAC_ADDRESS_LIST=($(echo "$NODES" | cut -d , -f 1)) # sorted MAC addresses will be used to assign the IP addresses
   FULL_BMC_MAC_ADDRESS_LIST=($(echo "$NODES" | cut -d , -f 2))
   CONTROLLERS="$(echo "$NODES" | grep -m "$CONTROLLER_AMOUNT" "[ ,]$CONTROLLER_TYPE")"

--- a/installer/racker
+++ b/installer/racker
@@ -39,6 +39,7 @@ usage() {
     ["get VERSION"]="install a particular racker version"
     ["factory"]="preparation procedure to configure the hardware"
     ["version"]="print racker version"
+    ["--exclude='MAC...'"]="bootstrap: exclude these nodes from provisioning, expects a string containing a white-space separated list of MAC addresses"
     ["--onfailure=(ask|retry|cancel)"]="bootstrap: behavior on provisioning failure (default: ask)"
     ["--retries=X"]="bootstrap: if --onfailure=retry is set, the number of retries before giving up (default: 3)"
     ["-h/--help"]="show usage"
@@ -53,13 +54,18 @@ usage() {
   exit 1
 }
 
-ARGS=$(getopt -n "$0" -o ho:r: -l help,onfailure:,retries: -- "$@")
+ARGS=$(getopt -n "$0" -o he:o:r: -l help,exclude:,onfailure:,retries: -- "$@")
 eval set -- "$ARGS"
 
 while true; do
   case "${1:-}" in
     -h|--help)
       usage
+      ;;
+    --exclude)
+      shift
+      export EXCLUDE_NODES="$1"
+      shift
       ;;
     --onfailure)
       shift


### PR DESCRIPTION
Some nodes may be known to have an error and should be excluded from
provisioning in advance. Later we can add a way to exclude a node
on-the-fly and consider to move this parameter into the wizard.
