### PR TITLE
wizard: Do not check for answers when dealing with skipped flags

### DIFF
--- a/wizard/args-wizard.go
+++ b/wizard/args-wizard.go
@@ -278,7 +278,12 @@ func main() {
 				continue
 			}
 
-			ans := answers[argName]
+			ans, ok := answers[argName]
+
+			// Flags that are skipped will not be present on answers.
+			if !ok {
+				continue
+			}
 
 			s := ""
 			sPtr, ok := ans.(*string)


### PR DESCRIPTION
Skipped flags will not be processed and thus will not be present in the
answer map internally.
