### PR TITLE
installer/racker: update local cache of the versioned image on upgrade

### DIFF
--- a/installer/racker
+++ b/installer/racker
@@ -82,6 +82,12 @@ if [ "$1" = update ]; then
   pull_n_run_racker $IMAGE $VERSION
 elif [ "$1" = upgrade ]; then
   pull_n_run_racker $IMAGE "latest"
+  VERSION=$(cat /opt/racker/RACKER_VERSION 2> /dev/null || true)
+  if [ "$VERSION" = "" ]; then
+    echo "Could not detect new version to update the local image cache"
+    exit 1
+  fi
+  pull_image $IMAGE $VERSION
 elif [ "$1" = get ]; then
   VERSION=${2:-$VERSION}
   pull_n_run_racker $IMAGE $VERSION


### PR DESCRIPTION
When "racker upgrade" pulls and extracts the "latest" image it writes a
version file with the concrete version. This is later used to run that
version of the Docker image but it could be outdated since it wasn't
explicitly pulled again.
Update the local cache to have the latest content of the versioned
image.
