### PR TITLE
installer/racker: don't overwrite global variable in function

### DIFF
--- a/installer/racker
+++ b/installer/racker
@@ -23,8 +23,8 @@ if [ "${VERSION}" = "" ]; then
 fi
 
 run_racker() {
-  VERSION=${2:-"latest"}
-  IMAGE="$1:$VERSION"
+  local VERSION=${2:-"latest"}
+  local IMAGE="$1:$VERSION"
 
   echo "Running $IMAGE"
 
@@ -32,8 +32,8 @@ run_racker() {
 }
 
 pull_image() {
-  VERSION=${2:-"latest"}
-  IMAGE="$1:$VERSION"
+  local VERSION=${2:-"latest"}
+  local IMAGE="$1:$VERSION"
 
   echo "Getting $IMAGE"
 


### PR DESCRIPTION
The global IMAGE variable holds the image name without the image tag.
When the function makes its own IMAGE variable that combines both
image name and image tag, this should not corrupt the global variable.
Mark the function variables as local to protect against overwriting the
global variable.


## How to use

`racker upgrade` used to fail fetching the versioned image after fetching the `latest` image.

## Testing done

Modified `/opt/bin/racker` with the change and now `racker upgrade` can fetch the versioned image.