### PR TITLE
bootstrap/status: show server power status in table

### DIFF
--- a/bootstrap/status.sh
+++ b/bootstrap/status.sh
@@ -40,13 +40,15 @@ else
 fi
 
 echo
-echo "MAC address        BMC reached  OS provisioned  Joined cluster   Hostnames"
+echo "MAC address        BMC reached  Power   OS provisioned  Joined cluster   Hostnames"
 full_report=""
 for mac in ${FULL_MAC_ADDRESS_LIST[*]}; do
   printf "${mac}\t"
-  report=$("${SCRIPTFOLDER}"/ipmi "${mac}" diag 2>&1) && printf "✓\t" || printf "×\t"
-  printf "\t"
+  # cut away \r from the ipmitool output
+  report=$("${SCRIPTFOLDER}"/ipmi "${mac}" diag 2>&1 | sed 's/\r//g') && printf "✓\t" || printf "×\t"
   full_report+="${report}"$'\n\n'
+  power=$(echo "${report}" | { grep -m 1 "^System Power" || true ; } | cut -d : -f 2 | xargs)
+  printf " ${power}\t\t"
   if [ "${MAC_STATE}" != "" ] && [ -f "${MAC_STATE}"/"${mac}" ]; then
     printf "✓\t"
   else

--- a/docs/usage/after_provisioning.md
+++ b/docs/usage/after_provisioning.md
@@ -178,10 +178,10 @@ the nodes, so one can use SSH or the IPMI serial console to access the nodes:
 ```
 Provisioned: Lokomotive
 Kubernetes API reached: yes
-MAC address        BMC reached  OS provisioned  Joined cluster Hostnames
-aa:bb:cc:dd:ee:11       ✓               ✓               ✓      l.k8s l-controller-0.k8s
-aa:bb:cc:dd:ee:22       ✓               ×               ×
-aa:bb:cc:dd:ee:33       ✓               ✓               ✓      l-worker-2.k8s
+MAC address        BMC reached  Power   OS provisioned  Joined cluster   Hostnames
+aa:bb:cc:dd:ee:11       ✓        on             ✓               ✓        l.k8s l-contr…
+aa:bb:cc:dd:ee:22       ✓        on             ×               ×
+aa:bb:cc:dd:ee:33       ✓        on             ✓               ✓        l-worker-2.k8s
 ```
 
 When run as `racker status -full` it will also show the `ipmi diag` output (see below) for all nodes after the above table output.


### PR DESCRIPTION
The servers may be turned off for some reason which makes them
unreachable.
To quickly discover that a server is not on, include the power status
in the output of "racker status".

## Testing done

```
MAC address        BMC reached  Power   OS provisioned  Joined cluster   Hostnames
0c:42:11:11:11:11	✓	 off		×		○	 lokomotive.k8s.localdomain lokomotive-controller-0.k8s.localdomain
0c:42:22:22:22:22	✓	 on		×		○	 lokomotive.k8s.localdomain lokomotive-controller-1.k8s.localdomain

```