### PR TITLE
bootstrap/provision-type.yaml: fix env var name for -onfailure

### DIFF
--- a/bootstrap/provision-type.yaml
+++ b/bootstrap/provision-type.yaml
@@ -1,7 +1,7 @@
 ignore-unknown-flags: true
 args:
 - name: onfailure
-  var: ON_FAILURE
+  var: ONFAILURE
   default: ask
   help: "behavior on provisioning failure; options are: ask|retry|exclude|cancel."
   flag:


### PR DESCRIPTION
The -onfailure= flag did not work because it set up the wrong variable
name.
Use the correct name for the env var that gets passed along.

