### PR TITLE
bootstrap/racker-factory: fix validate node type output

### DIFF
--- a/bootstrap/racker-factory.sh
+++ b/bootstrap/racker-factory.sh
@@ -142,7 +142,7 @@ validate() {
   else
     echo "🛈 $num_node_types node types configured:"
     count=0
-    for i in $(uniq <<< $node_types_list); do
+    for i in $(uniq <<< "$node_types_list"); do
       # Count the nodes of this type and print the result with the type
       echo "  $(echo "$node_types_list" | grep $i | wc -l) \"$i\""
       count=$(($count + 1))


### PR DESCRIPTION
The summary output of node types was broken because uniq got called
on a single-line input due to missing quoting that could have preserved
the line breaks.
Quote the variable to preserve line breaks which are needed for uniq to
filter.
