### PR TITLE
installer/racker: allow status --full besides status -full

### DIFF
--- a/installer/racker
+++ b/installer/racker
@@ -97,7 +97,7 @@ elif [ "$1" = factory ]; then
   shift
   /opt/racker/bootstrap/racker-factory.sh "$@"
 elif [ "$1" = status ]; then
-  if [ "${2:-}" = "-full" ]; then
+  if [ "${2:-}" = "-full" ] || [ "${2:-}" = "--full" ]; then
     STATUS_ARG="--full"
   fi
   /opt/racker/bootstrap/status.sh ${STATUS_ARG:-}


### PR DESCRIPTION
If the user sets --full as argument instead of -full out of habit, we
should handle it, too, because the runtime of the status command may
be long and it is annoying to rerun it due to a wrong argument.
