### PR TITLE
bootstrap/ipmi: retry getting BMC IP address

### DIFF
--- a/bootstrap/ipmi
+++ b/bootstrap/ipmi
@@ -7,11 +7,14 @@ source "${SCRIPTFOLDER}"/common.sh
 
 USE_STDIN=${USE_STDIN:-"1"}
 USE_TTY=${USE_TTY:-"1"}
+# wait for max 2 minutes DHCP lease time plus 30 secs margin against races with the ARP scanner
+RETRY_SEC=${RETRY_SEC:-"150"}
 if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "Usage: $0 domain|primary-mac|bmc-mac|--all diag|[ipmitool commands]"
   echo "If no command is given, defaults to \"sol activate\" for attaching the serial console (should not be used with --all)."
   echo "The \"diag\" command shows the BMC MAC address, BMC IP address, and the IPMI \"chassis status\" output."
   echo "This helper requires a tty and attaches stdin by default, for usage in scripts set the env vars USE_STDIN=0 USE_TTY=0 as needed."
+  echo "When the BMC IP address can't be found, the helper will retry for ${RETRY_SEC} seconds, configurable through the env var RETRY_SEC."
   exit 1
 fi
 if [ $# -gt 1 ]; then
@@ -67,11 +70,19 @@ RACKER_VERSION=$(cat /opt/racker/RACKER_VERSION 2> /dev/null || true)
 if [ "${RACKER_VERSION}" = "" ]; then
   RACKER_VERSION="latest"
 fi
-IP_ADDR="$(docker run --privileged --net host --rm quay.io/kinvolk/racker:${RACKER_VERSION} sh -c "arp-scan -q -l -x -T $BMC --interface ${PXE_INTERFACE} | { grep -m 1 $BMC || true ; } | cut -f 1")"
-if [ "${IP_ADDR}" = "" ]; then
-  echo "Error getting BMC IP address for ${BMC} via ${PXE_INTERFACE}"
-  exit 1
-fi
+
+END=$(( $(date '+%s') + RETRY_SEC ))
+while true; do
+  IP_ADDR="$(docker run --privileged --net host --rm quay.io/kinvolk/racker:${RACKER_VERSION} sh -c "arp-scan -q -l -x -T $BMC --interface ${PXE_INTERFACE} | { grep -m 1 $BMC || true ; } | cut -f 1")"
+  if [ "${IP_ADDR}" = "" ] && [ "$(date '+%s')" -gt "${END}" ]; then
+    echo "Error getting BMC IP address for ${BMC} via ${PXE_INTERFACE}"
+    exit 1
+  fi
+  if [ "${IP_ADDR}" != "" ]; then
+    break
+  fi
+done
+
 IP_ADDR_EXPECTED="$({ grep -m 1 "${BMC}" /opt/racker-state/dnsmasq/dnsmasq.conf || true ; } | cut -d = -f 2 | cut -d , -f 2)"
 if [ "${IP_ADDR}" != "${IP_ADDR_EXPECTED}" ]; then
   echo "Warning: BMC IP address does not match the static IP address set up with dnsmasq, expected \"${IP_ADDR_EXPECTED}\""

--- a/docs/management_node.md
+++ b/docs/management_node.md
@@ -193,8 +193,8 @@ racker status
 ```
 
 If the BMCs were not reachable, check their MAC addresses and the wireing of the NICs to the internal switch.
-In case the internal subnet or the MAC address list was changed you should wait 2 minutes before retrying so that the BMCs had a chance to pick up the new IP addresses via DHCP.
-If there was a previous DHCP configuration with a longer lease time, you can also try to power-cycle the rack to force a DHCP renewal or first switch to the old subnet with `racker bootstrap … -subnet-prefix a.b.c` and then run `ipmi --all lan set 1 ipsrc dhcp` which should trigger a DHCP renewal.
+In case the internal subnet or the MAC address list was changed you should check whether the BMCs picked up the new IP addresses via DHCP.
+If there was a previous DHCP configuration with a long lease time, you can also try to power-cycle the rack to force a DHCP renewal or first switch to the old subnet with `racker bootstrap … -subnet-prefix a.b.c` and then run `ipmi --all lan set 1 ipsrc dhcp` which should trigger a DHCP renewal.
 If IPMI static IP addressing was manually configured on the BMCs you have to switch the BMCs back to DHCP (either manually or by switching to the same subnet with `racker bootstrap … -subnet-prefix a.b.c` and then running `ipmi --all lan set 1 ipsrc dhcp`).
 
 If the OS was not provisioned, connect to the problematic node via `ipmi MACADDR` and see whether the PXE-booted system hangs during the installation or whether the final OS hangs during bootup.

--- a/docs/usage/after_provisioning.md
+++ b/docs/usage/after_provisioning.md
@@ -309,8 +309,8 @@ $ ipmi --all chassis power off
 When MAC addresses have changed due to a hardware replacement or when new servers were added you need to update the `/usr/share/oem/nodes.csv` file with the new MAC addresses.
 You can mimic the other entries for the node type and whether a secondary MAC address is present.
 Finally, run `racker bootstrap` again to provision a new cluster, which will destroy the old cluster.
-Since the BMCs may still have an old IP address, `racker bootstrap` may fail and you may need to retry after 2 minutes so that the BMCs had a chance to pick up the new IP addresses via DHCP.
-If there was a previous DHCP configuration with a longer lease time, you can also try to power-cycle the rack to force a DHCP renewal or first switch to the old subnet with `racker bootstrap … -subnet-prefix a.b.c` and then run `ipmi --all lan set 1 ipsrc dhcp` which should trigger a DHCP renewal.
+In case the BMCs are not reachable, `racker bootstrap` may fail and you may need to check that the BMCs picked up the new IP addresses via DHCP.
+If there was a previous DHCP configuration with a long lease time, you can also try to power-cycle the rack to force a DHCP renewal or first switch to the old subnet with `racker bootstrap … -subnet-prefix a.b.c` and then run `ipmi --all lan set 1 ipsrc dhcp` which should trigger a DHCP renewal.
 If the IPMI static IP addressing was manually configured on the BMCs you have to switch the BMCs back to DHCP (either manually or by switching to the same subnet with `racker bootstrap … -subnet-prefix a.b.c` and then running `ipmi --all lan set 1 ipsrc dhcp`).
 
 ### Workaround for a running cluster
@@ -322,8 +322,8 @@ In case you can't destroy the running cluster, a workaround is to do some manual
 * Create or update the `cl/DOMAIN.yaml` files to have the networkd unit for the primary MAC address. The `cl/DOMAIN-custom.yaml` file may need to contain a networkd unit for the public static IP address for the secondary MAC address.
 * Add or update the entries in `/etc/hosts` for the internal IP addresses.
 * Now run `lokoctl cluster apply` or `terraform apply` to provision the added nodes.
-* **Note:** When creating a new cluster later by running `racker bootstrap` it may fail because the BMCs still use the old IP addresses but the automatic assignment will order the new IP addresses different to the manual assignment after the `nodes.csv` file got changed. You may need to retry after 2 minutes so that the BMCs had a chance to pick up the new IP addresses via DHCP.
-If there was a previous DHCP configuration with a longer lease time, you can also try to power-cycle the rack to force a DHCP renewal or first switch to the old subnet with `racker bootstrap … -subnet-prefix a.b.c` and then run `ipmi --all lan set 1 ipsrc dhcp` which should trigger a DHCP renewal.
+* **Note:** When creating a new cluster later by running `racker bootstrap` and it fails because the BMCs are reachable, check that they don't use old IP addresses but picked up new ones via DHCP but the automatic assignment will order the new IP addresses different to the manual assignment after the `nodes.csv` file got changed.
+If there was a previous DHCP configuration with a long lease time, you can also try to power-cycle the rack to force a DHCP renewal or first switch to the old subnet with `racker bootstrap … -subnet-prefix a.b.c` and then run `ipmi --all lan set 1 ipsrc dhcp` which should trigger a DHCP renewal.
 If the IPMI static IP addressing was manually configured on the BMCs you have to switch the BMCs back to DHCP (either manually or by switching to the same subnet with `racker bootstrap … -subnet-prefix a.b.c` and then running `ipmi --all lan set 1 ipsrc dhcp`).
 
 ## IPMI Credentials

--- a/docs/usage/bootstrap.md
+++ b/docs/usage/bootstrap.md
@@ -140,7 +140,7 @@ In any case, the cluster bring up will directly work without further action:
 **Subnet prefix:** The subnet prefix of the rack-internal network defines the IP addresses of the BMCs and the internal NICs.
 Two racks can have the same subnet prefix because the networks don't known about each other.
 Therefore, you should only change this if the default clashes with the external network.
-If you had another value before, you may need to retry after 2 minutes so that the BMCs had a chance to pick up the new IP addresses via DHCP.
+If you had another value before, getting IPMI connectivity may take up to 2 minutes because the BMCs have to pick up the new IP addresses via DHCP.
 If there was a previous DHCP configuration with a longer lease time, you can also try to power-cycle the rack to force a DHCP renewal or first switch to the old subnet with `racker bootstrap … -subnet-prefix a.b.c` and then run `ipmi --all lan set 1 ipsrc dhcp` which should trigger a DHCP renewal.
 If the IPMI static IP addressing was manually configured on the BMCs you have to switch the BMCs back to DHCP (either manually or by switching to the same subnet with `racker bootstrap … -subnet-prefix a.b.c` and then running `ipmi --all lan set 1 ipsrc dhcp`).
 


### PR DESCRIPTION
After a reconfiguration of the nodes.csv file or the subnet, the BMC
may take up to two minutes to get the new IP address via DHCP.
Wait for max. 2 minutes plus a 30 secs margin against races with the
    ARP scanner.

## How to use

During bootstrap, take a different subnet than the default

## Testing done

With the slight margin it works well