### PR TITLE
bootstrap: capture Docker ipmitool without \r and stdin

### DIFF
--- a/bootstrap/ipmi
+++ b/bootstrap/ipmi
@@ -29,6 +29,7 @@ if [ "${NODE}" = "--all" ]; then
   # Skip header line, filter out the management node itself and sort by MAC address
   NODES="$(tail -n +2 /usr/share/oem/nodes.csv | { grep -v -f <(cat /sys/class/net/*/address) || true ; } | sort)"
   FULL_BMC_MAC_ADDRESS_LIST=($(echo "$NODES" | cut -d , -f 2))
+  export USE_STDIN USE_TTY RETRY_SEC
   for NODE in ${FULL_BMC_MAC_ADDRESS_LIST[*]}; do
     echo "Output for ${NODE}:"
     "${SCRIPTFOLDER}"/ipmi "${NODE}" ${CMD} || echo "Failed"

--- a/bootstrap/prepare.sh
+++ b/bootstrap/prepare.sh
@@ -691,7 +691,7 @@ function bmc_check() {
       tput ed
       ELLIPSIS=$(printf '.%.0s' $(seq ${ellipsis}))
       echo "➤ Checking BMC connectivity (${found}/${all})${ELLIPSIS}"
-      report=$("${SCRIPTFOLDER}"/ipmi "${mac}" diag 2>&1) && let found+=1 || {
+      report=$(USE_TTY=0 USE_STDIN=0 "${SCRIPTFOLDER}"/ipmi "${mac}" diag 2>&1) && let found+=1 || {
         errors+="Error while checking BMC connectivity for ${mac}:"$'\n'"${report}"
         error_macs+=("${mac}")
       }

--- a/bootstrap/status.sh
+++ b/bootstrap/status.sh
@@ -44,8 +44,7 @@ echo "MAC address        BMC reached  Power   OS provisioned  Joined cluster   H
 full_report=""
 for mac in ${FULL_MAC_ADDRESS_LIST[*]}; do
   printf "${mac}\t"
-  # cut away \r from the ipmitool output
-  report=$("${SCRIPTFOLDER}"/ipmi "${mac}" diag 2>&1 | sed 's/\r//g') && printf "✓\t" || printf "×\t"
+  report=$(USE_TTY=0 USE_STDIN=0 "${SCRIPTFOLDER}"/ipmi "${mac}" diag 2>&1) && printf "✓\t" || printf "×\t"
   full_report+="${report}"$'\n\n'
   power=$(echo "${report}" | { grep -m 1 "^System Power" || true ; } | cut -d : -f 2 | xargs)
   printf " ${power}\t\t"


### PR DESCRIPTION
When Docker is run with allocating a TTY it will result in \r\n
instead of \n which can break regular output postprocessing.
This was worked around in one case but we can also avoid it by not
allocating a TTY.
Disable the -t flag through the ipmi helper script env var and also
disable reading from stdin which wasn't intended anyway.
