### PR TITLE
rook: Equal is an invalid value

### DIFF
--- a/bootstrap/rook.lokocfg
+++ b/bootstrap/rook.lokocfg
@@ -15,7 +15,7 @@ component "rook-ceph" {
   }
   node_affinity {
     key      = "storage.lokomotive.io"
-    operator = "Equal"
+    operator = "In"
     values    = ["rook"]
   }
 }


### PR DESCRIPTION
This commit fixes the invalid value for node affinity.
Correct value is `Equals`, instead of `Equal`.

Signed-off-by: Imran Pochi <imran@kinvolk.io>