### PR TITLE
Add QEMU IPMI simulator environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ servers are on a public network. This allows to reach the management node's BMC 
 while the management node itself has full control over the BMCs of the rack, serving DHCP to
 them and interfacing with IPMI to control the PXE booting.
 
+## Test it in VMs
+
+You can use the [racker-sim](racker-sim/) `ipmi-env.sh` script to create a VM environment that simulates IPMI.
+This allows you to run Racker without requiring a free rack.
+
 ## Installer
 
 The installer is delivered as a container image but extracted in the host and

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -22,3 +22,5 @@ them and interfacing with IPMI to control the PXE booting.
 The solution consist of an installer for the management node, which is run once, and a command line utility run on the management node at any later point.
 
 ![Overview](overview.svg)
+
+If you don't have a free rack to test this, you can use the IPMI simulator with VMs from the [racker-sim folder](https://github.com/kinvolk/racker/tree/main/racker-sim).

--- a/racker-sim/README.md
+++ b/racker-sim/README.md
@@ -1,0 +1,37 @@
+# QEMU IPMI simulator environment
+
+To test Racker without a special hardware you can use the QEMU test environment which sets up an IPMI emulator.
+It behaves like an IPMI-compatible rack with a TOR switch for the public network on the secondary NICs and a second switch for the rack-internal network
+for the primary NICs and the BMCs. The management node has swapped cables so that the primary NIC and BMC is on the public network and the secondary NIC
+can manage the rack-internal network for DHCP/PXE.
+
+Here the usage of `ipmi-env.sh` with the `nodes.csv` file in this folder where `00:11:22:33:44:00` is picked as management node:
+
+```
+wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
+bunzip2 flatcar_production_qemu_image.img.bz2
+QEMU_ARGS="" ./ipmi-env.sh create nodes.csv 00:11:22:33:44:00 ./flatcar_production_qemu_image.img /var/tmp/ipmi-sim
+```
+
+To access the management node use the opened QEMU VGA console,
+or `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 22 core@192.168.254.X` where `X` is the IP address you can see in QEMU with `ip a`,
+or `ipmitool -C3 -I lanplus -H localhost -p 9011 -U USER -P PASS sol activate` where you can run `echo ssh-rsa AAA... me@mail.com > .ssh/authorized_keys` to
+add your SSH pub key.
+
+Follow the Racker manual PDF on how to install Racker in the management node (`sudo docker run..` and create the `nodes.csv` file under `/usr/share/oem/` etc).
+The IPMI user is `USER` and the password is `PASS`.
+Here a short quick start if you skipped reading the PDF:
+
+```
+echo USER | ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 22 core@192.168.254.X sudo tee /usr/share/oem/ipmi_user
+echo PASS | ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 22 core@192.168.254.X sudo tee /usr/share/oem/ipmi_password
+cat nodes.csv | ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 22 core@192.168.254.X sudo tee /usr/share/oem/nodes.csv
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 22 core@192.168.254.X
+# To install Racker run: sudo docker run --rm --privileged --pid host quay.io/kinvolk/racker:latest
+#                        racker factory check
+# Afterwards to provision a cluster run: racker bootstrap
+```
+
+You can pass the `PUBLIC_BRIDGE_PREFIX` env var to `ipmi-env.sh` to choose another /24 subnet prefix for the public bridge, the last byte will be appended (default `192.168.254`).
+
+By default no VM windows are created because the `QEMU_ARGS` env var defaults to `-nographic` but you can overwrite it as done above with `QEMU_ARGS=""` to have VM windows pop up (requires X11/Wayland).

--- a/racker-sim/chassis
+++ b/racker-sim/chassis
@@ -1,0 +1,59 @@
+#!/bin/bash
+ID="$1"
+PRIMARY="$2"
+BMC="$3"
+SEC="$4"
+TAP0="$5"
+TAP1="$6"
+IMAGE="$7"
+
+B="$8"
+C="$9"
+D="${10}"
+set -euo pipefail
+
+who="$ID"
+
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+state="/tmp/ipmi-sim/${who}"
+mkdir -p "$state"
+
+if [ "$B $C $D" = "set power 1" ]; then
+  pid=$(cat "${state}/pid" 2>/dev/null || echo 9999999999999999)
+  if [ -e "/proc/${pid}/" ]; then
+    echo "VM ${ID} is already running" > /dev/stderr
+    true
+  else
+    boot=$(cat "${state}/boot" 2>/dev/null || echo "default")
+    echo "Starting VM ${ID} (${boot})" > /dev/stderr
+    set +e
+    "${SCRIPTFOLDER}/qemu-wrap" "${ID}" "${PRIMARY}" "${BMC}" "${SEC}" "${TAP0}" "${TAP1}" "${IMAGE}" "${boot}" &
+    set -e
+  fi
+elif [ "$B $C $D" = "set power 0" ]; then
+  pid=$(cat "${state}/pid" 2>/dev/null || echo 9999999999999999)
+  echo "Terminating VM ${ID} (PID ${pid})" > /dev/stderr
+  rm -f "${state}/pid" 2>/dev/null
+elif [ "$B $C" = "get power" ]; then # e.g., chassis status, power status
+  pid=$(cat "${state}/pid" 2>/dev/null || echo 9999999999999999)
+  if [ -e "/proc/${pid}/" ]; then
+    echo "Reporting VM ${ID} power (on)" > /dev/stderr
+    echo "power:1"
+  else
+    echo "Reporting VM ${ID} power (off)" > /dev/stderr
+    echo "power:0"
+  fi
+elif [ "$B $C" = "get boot" ]; then # e.g., chassis bootparam get 5
+  boot=$(cat "${state}/boot" 2>/dev/null || echo "default")
+  echo "Reporting VM ${ID} boot (${boot})" > /dev/stderr
+  echo "boot:${boot}"
+elif [ "$B $C $D" = "set boot default" ] || [ "$B $C $D" = "set boot disk" ] || [ "$B $C $D" = "set boot none" ]; then # chassis bootdev disk (or raw .. for efi)
+  echo "Marked VM ${ID} to boot with ${D}" > /dev/stderr
+  echo "$D" > "${state}/boot"
+elif [ "$B $C $D" = "set boot pxe" ]; then # chassis bootdev pxe (or raw ... for efi)
+  echo "Marked VM ${ID} to boot with ${D}" > /dev/stderr
+  echo "$D" > "${state}/boot"
+else
+  echo "Error, unimplemented: $B $C $D" > /dev/stderr
+  exit 1
+fi

--- a/racker-sim/ipmi-env.sh
+++ b/racker-sim/ipmi-env.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 COMMAND|-h|--help"
+  echo "Commands:"
+  echo "  create NODES_FILE MGMT_NODE_MAC MGMT_NODE_IMAGE DISK_FOLDER"
+  echo "    Creates a QEMU VM for every entry in the nodes.csv file with primary and secondary NICS,"
+  echo "    a public bridge with NAT, IP forwarding, and DHCP for the secondary NICs, an internal bridge for the primary NICs,"
+  echo "    and IPMI simulators for the primary NICs connected to the bridge with a DHCP client in its own network namespace."
+  echo "    The management node has the bridges swapped so that the primary NIC is on the public bridge while the secondary"
+  echo "    NIC is on the L2 bridge and should itself serve DHCP/PXE."
+  echo "    The VM image for the management node can be prepared beforehand and you can use IPMI serial console or SSH on the public bridge to access it."
+  echo "    During setup the empty disk images for the other nodes are created with 10 GB and a 6 GB secondary disk in the DISK_FOLDER (must not contain whitespace)."
+  echo "    Each VM node has 2.5 GB RAM (currently minimum for a working K8s cluster) except for the management node which has 1 GB RAM."
+  echo
+  echo "    The env var PUBLIC_BRIDGE_PREFIX defaults to 192.168.254 as prefix for the public bridge /24 subnet and can be customized."
+  echo '    The env var QEMU_ARGS defaults to -nographic and can be customized to open VGA console windows (QEMU_ARGS="").'
+  echo "    The IPMI user is USER and the password is PASS."
+  exit 1
+fi
+
+/bin/which ipmi_sim &> /dev/null || { echo "ipmi_sim not found: Install the ipmi_sim binary from your distribution" > /dev/stderr ; exit 1 ; }
+/bin/which socat &> /dev/null || { echo "socat not found: Install the socat binary from your distribution" > /dev/stderr ; exit 1 ; }
+/bin/which qemu-system-x86_64 &> /dev/null || { echo "qemu-system-x86_64 not found: Install the qemu-system-x86_64 binary from your distribution" > /dev/stderr ; exit 1 ; }
+/bin/which qemu-img &> /dev/null || { echo "qemu-img not found: Install the qemu-img binary from your distribution" > /dev/stderr ; exit 1 ; }
+/bin/which unshare &> /dev/null || { echo "unshare not found: Install the unshare binary from your distribution" > /dev/stderr ; exit 1 ; }
+/bin/which nsenter &> /dev/null || { echo "nsenter not found: Install the nsenter binary from your distribution" > /dev/stderr ; exit 1 ; }
+/bin/which dhclient &> /dev/null || { echo "dhclient not found: Install the dhclient binary from your distribution" > /dev/stderr ; exit 1 ; }
+/bin/which ip &> /dev/null || { echo "ip not found: Install the ip binary from your distribution" > /dev/stderr ; exit 1 ; }
+/bin/which docker &> /dev/null || { echo "docker not found: Install the docker binary (or Podman compability wrapper) from your distribution" > /dev/stderr ; exit 1 ; }
+/bin/which sudo &> /dev/null || { echo "sudo not found: Install the sudo binary from your distribution" > /dev/stderr ; exit 1 ; }
+
+PUBLIC_BRIDGE_PREFIX="${PUBLIC_BRIDGE_PREFIX:-"192.168.254"}"
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+
+function destroy_network() {
+  echo "Destroying internal network bridge"
+  sudo ip link delete internal-br type bridge || true
+
+  echo "Destroying public network bridge"
+  sudo ip link delete public-br type bridge || true
+}
+
+function create_network() {
+  destroy_network
+
+  echo "Creating public network bridge"
+  sudo ip link add name public-br type bridge
+  sudo ip link set public-br up
+  sudo ip addr add dev public-br "${PUBLIC_BRIDGE_PREFIX}.1/24" broadcast "${PUBLIC_BRIDGE_PREFIX}.255"
+
+  echo "Creating internal network bridge"
+
+  sudo ip link add name internal-br type bridge
+  sudo ip link set internal-br up
+
+  # Setup NAT Internet access for the public bridge
+  sudo iptables -P FORWARD ACCEPT
+  sudo iptables -t nat -A POSTROUTING -o $(ip route get 1 | grep -o -P ' dev .*? ' | cut -d ' ' -f 3) -j MASQUERADE
+}
+
+# regular DHCP on the external bridge (as libvirt would do)
+function prepare_dnsmasq_external_conf() {
+  cat << EOF
+no-daemon
+dhcp-range=${PUBLIC_BRIDGE_PREFIX}.2,${PUBLIC_BRIDGE_PREFIX}.254,255.255.255.0
+dhcp-option=3,${PUBLIC_BRIDGE_PREFIX}.1
+log-queries
+log-dhcp
+except-interface=lo
+interface=public-br
+bind-interfaces
+EOF
+}
+
+function destroy_containers() {
+  echo "Destroying container dnsmasq-external"
+  sudo docker stop dnsmasq-external || true
+  sudo docker rm dnsmasq-external || true
+}
+
+function create_containers() {
+  destroy_containers
+
+  echo "Creating container dnsmasq-external"
+
+  CONF=$(mktemp)
+  prepare_dnsmasq_external_conf > "${CONF}"
+
+  sudo docker run --name dnsmasq-external \
+    -d \
+    --cap-add=NET_ADMIN --cap-add=NET_RAW \
+    -v "${CONF}:/etc/dnsmasq.conf:Z" \
+    --net=host \
+    quay.io/poseidon/dnsmasq:d40d895ab529160657defedde36490bcc19c251f -d || { rm "${CONF}"; exit 1 ; }
+  rm "${CONF}"
+}
+
+function command_file() {
+  for entry in "${ENTRIES_MGMT_FIRST[@]}"; do
+    unpack=(${entry})
+    ID="${unpack[0]}"
+    PRIMARY="${unpack[1]}"
+    BMC="${unpack[2]}"
+    SEC="${unpack[3]}"
+    TAP0="${unpack[4]}"
+    TAP1="${unpack[5]}"
+    IMAGE="${unpack[6]}"
+    STARTNOW="${unpack[7]}"
+    ADDR="0x$(( ID + 1 ))0"
+    cat << EOF
+mc_setbmc ${ADDR}
+mc_add ${ADDR} 0 no-device-sdrs 0x23 9 8 0x9f 0x1291 0xf02 persist_sdr
+sel_enable ${ADDR} 1000 0x0a
+sensor_add ${ADDR} 0 0 35 0x6f event-only
+sensor_set_event_support 0x20 0 0 enable scanning per-state \
+    000000000001111 000000000000000 \
+    000000000001111 000000000000000
+sensor_add ${ADDR} 0 1 0x01 0x01
+sensor_set_value ${ADDR} 0 1 0x60 0
+sensor_set_threshold ${ADDR} 0 1 settable 111000 0xa0 0x90 0x70 00 00 00
+sensor_set_event_support 0x20 0 1 enable scanning per-state \
+    000111111000000 000111111000000 \
+    000111111000000 000111111000000
+sensor_add ${ADDR} 0 2 37 0x6f
+sensor_set_bit_clr_rest ${ADDR} 0 2 1 1
+sensor_set_event_support ${ADDR} 0 2 enable scanning per-state \
+    000000000000011 000000000000011 \
+    000000000000011 000000000000011
+mc_enable ${ADDR}
+EOF
+  done
+}
+
+function config_file() {
+  echo 'name "ipmisim1"'
+  for entry in "${ENTRIES_MGMT_FIRST[@]}"; do
+    unpack=(${entry})
+    ID="${unpack[0]}"
+    PRIMARY="${unpack[1]}"
+    BMC="${unpack[2]}"
+    SEC="${unpack[3]}"
+    TAP0="${unpack[4]}"
+    TAP1="${unpack[5]}"
+    IMAGE="${unpack[6]}"
+    STARTNOW="${unpack[7]}"
+    ADDR="0x$(( ID + 1 ))0"
+    cat << EOF
+set_working_mc ${ADDR}
+startlan 1
+addr :: 90${ID}1
+priv_limit admin
+allowed_auths_callback none md2 md5 straight
+allowed_auths_user none md2 md5 straight
+allowed_auths_operator none md2 md5 straight
+allowed_auths_admin none md2 md5 straight
+guid a123456789abcdefa123456789abcdef
+endlan
+chassis_control "${SCRIPTFOLDER}/chassis ${ID} ${PRIMARY} ${BMC} ${SEC} ${TAP0} ${TAP1} ${IMAGE}"
+poweroff_wait 1
+kill_wait 1
+serial 15 localhost 90${ID}2 codec VM
+startcmd "${SCRIPTFOLDER}/qemu-wrap ${ID} ${PRIMARY} ${BMC} ${SEC} ${TAP0} ${TAP1} ${IMAGE} disk"
+startnow ${STARTNOW}
+sol "telnet:localhost:90${ID}3" 115200
+user 1 true  ""     "test" user     10       none md2 md5 straight
+user 2 true  "USER" "PASS" admin    10       none md2 md5 straight
+EOF
+  done
+}
+
+function destroy_sim() {
+  for entry in "${ENTRIES_MGMT_FIRST[@]}"; do
+    unpack=(${entry})
+    ID="${unpack[0]}"
+    PRIMARY="${unpack[1]}"
+    BMC="${unpack[2]}"
+    SEC="${unpack[3]}"
+    TAP0="${unpack[4]}"
+    TAP1="${unpack[5]}"
+    IMAGE="${unpack[6]}"
+    STARTNOW="${unpack[7]}"
+    if [ "${ID}" != 1 ]; then
+      echo "Removing ${IMAGE}"
+      rm -f "${IMAGE}"
+      rm -f "${IMAGE}.disk2"
+    fi
+    echo "Removing ${DISK_FOLDER}/node${ID}-bmc ${DISK_FOLDER}/node${ID}-bmc-work"
+    sudo umount "${DISK_FOLDER}/node${ID}-bmc" || true
+    sudo umount -l "${DISK_FOLDER}/node${ID}-bmc" || true
+    sudo rm -rf "${DISK_FOLDER}/node${ID}-bmc" "${DISK_FOLDER}/node${ID}-bmc-work"
+    echo "Destroying veth node${ID}bmc"
+    sudo ip link delete "node${ID}bmc" type veth || true
+    echo "Destroying TAP ${TAP0} and ${TAP1}"
+    sudo ip link delete "${TAP0}" type tap || true
+    sudo ip link delete "${TAP1}" type tap || true
+  done
+}
+
+function create_sim() {
+  destroy_sim
+  for entry in "${ENTRIES_MGMT_FIRST[@]}"; do
+    unpack=(${entry})
+    ID="${unpack[0]}"
+    PRIMARY="${unpack[1]}"
+    BMC="${unpack[2]}"
+    SEC="${unpack[3]}"
+    TAP0="${unpack[4]}"
+    TAP1="${unpack[5]}"
+    IMAGE="${unpack[6]}"
+    STARTNOW="${unpack[7]}"
+    # Management node has swapped links with the primary NIC on the public bridge and the secondary NIC and BMC NIC on the internal bridge
+    if [ "${ID}" = 1 ]; then
+      target0=public-br
+      target1=internal-br
+    else
+      target0=internal-br
+      target1=public-br
+    fi
+    mkdir -p "${DISK_FOLDER}/node${ID}-bmc" "${DISK_FOLDER}/node${ID}-bmc-work"
+    sudo mount -t overlay overlay -o lowerdir=/,upperdir="${DISK_FOLDER}/node${ID}-bmc",workdir="${DISK_FOLDER}/node${ID}-bmc-work" "${DISK_FOLDER}/node${ID}-bmc"
+    sudo ip link add "node${ID}bmc" type veth peer name "node${ID}bmc0"
+    sudo ip link set dev "node${ID}bmc0" address "${BMC}"
+    sudo ip link set dev "node${ID}bmc" up
+    sudo ip link set "node${ID}bmc" master "${target0}"
+    exec {running_fd}>/dev/null
+    running="/proc/$$/fd/${running_fd}"
+    (
+    set +e
+    sudo unshare --mount-proc -n -R "${DISK_FOLDER}/node${ID}-bmc" sh -c "ip link set dev lo up; nsenter -a -t 1 ip link set node${ID}bmc0 netns \$\$; ip link set dev node${ID}bmc0 up; dhclient -d --no-pid & socat -T10 udp4-listen:623,reuseaddr,reuseport,fork exec:'nsenter -a -t 1 socat -T10 STDIO udp4\:127.0.0.1\:90${ID}1' & while [ -e '${running}' ]; do sleep 1; done; kill 0; exit 0" &
+    )
+    sudo ip tuntap add "${TAP0}" mode tap
+    sudo ip link set dev "${TAP0}" up
+    sudo ip tuntap add "${TAP1}" mode tap
+    sudo ip link set dev "${TAP1}" up
+    sudo ip link set "${TAP0}" master "${target0}"
+    sudo ip link set "${TAP1}" master "${target1}"
+    if [ "${ID}" != 1 ]; then
+      qemu-img create -f qcow2 "${IMAGE}" 10G
+      qemu-img create -f qcow2 "${IMAGE}.disk2" 6G
+    fi
+  done
+}
+
+function cancel() {
+  echo
+  echo "Terminating"
+  destroy_containers
+  destroy_network
+  destroy_sim
+  kill 0
+  exit 1
+}
+trap cancel INT
+
+if [ "$1" = create ]; then
+  if [ $# != 5 ]; then
+    echo "Expected 4 arguments"
+    exit 1
+  fi
+  NODES_CSV="$2"
+  MGMT_NODE_MAC="$3"
+  MGMT_NODE_IMAGE="$4"
+  DISK_FOLDER="$5"
+
+  NODES=$(tail -n +2 "${NODES_CSV}")
+  MGMT_NODE=$(echo "${NODES}" | { grep "${MGMT_NODE_MAC}" || true ; })
+  OTHER_NODES=$(echo "${NODES}" | { grep -v "${MGMT_NODE_MAC}" || true ; })
+  MGMT_NODE_PRIMARY_MAC=$(echo "${MGMT_NODE}" | cut -d , -f 1 | xargs)
+  OTHER_NODES_PRIMARY_MAC=$(echo "${OTHER_NODES}" | cut -d , -f 1 | xargs)
+  MGMT_NODE_BMC_MAC=$(echo "${MGMT_NODE}" | cut -d , -f 2 | xargs)
+  OTHER_NODES_BMC_MAC=$(echo "${OTHER_NODES}" | cut -d , -f 2 | xargs)
+  MGMT_NODE_SEC_MAC=$(echo "${MGMT_NODE}" | cut -d , -f 3 | xargs)
+  OTHER_NODES_SEC_MAC=$(echo "${OTHER_NODES}" | cut -d , -f 3 | xargs)
+  PRIMARY_MACS=(${MGMT_NODE_PRIMARY_MAC} ${OTHER_NODES_PRIMARY_MAC})
+  BMC_MACS=(${MGMT_NODE_BMC_MAC} ${OTHER_NODES_BMC_MAC})
+  SEC_MACS=(${MGMT_NODE_SEC_MAC} ${OTHER_NODES_SEC_MAC})
+
+  rm -rf /tmp/ipmi-sim
+  mkdir -p /tmp/ipmi-sim
+
+  # Array of white-space separated entries, first is the management node
+  ENTRIES_MGMT_FIRST=()
+  ID=1
+  for i in $(seq 0 $(( ${#PRIMARY_MACS[@]} - 1 ))); do
+    TAP0="node${ID}eth0"
+    TAP1="node${ID}eth1"
+    if [ "${ID}" = 1 ]; then
+      IMAGE="${MGMT_NODE_IMAGE}"
+      STARTNOW="true"
+    else
+      IMAGE="${DISK_FOLDER}/node${ID}.img"
+      STARTNOW="false"
+    fi
+    ENTRIES_MGMT_FIRST+=("${ID} ${PRIMARY_MACS[$i]} ${BMC_MACS[$i]} ${SEC_MACS[$i]} ${TAP0} ${TAP1} ${IMAGE} ${STARTNOW}")
+    ID=$(( ID + 1 ))
+  done
+  create_network
+  create_containers
+  create_sim
+
+  echo "Press Ctrl-C to quit"
+  config_file > /dev/stderr
+  command_file > /dev/stderr
+  ipmi_sim -d --config-file <(config_file) -f <(command_file) --nopersist -n
+  cancel
+else
+  echo "Unknown argument: $@"
+fi

--- a/racker-sim/nodes.csv
+++ b/racker-sim/nodes.csv
@@ -1,0 +1,4 @@
+Primary MAC address, BMC MAC address, Secondary MAC address, Node Type, Comments
+00:11:22:33:44:00, 00:11:22:33:44:01, 00:11:22:33:44:30, vm, mgmt node
+00:11:22:33:44:10, 00:11:22:33:44:11, 00:11:22:33:44:40, vma, one
+00:11:22:33:44:20, 00:11:22:33:44:21, 00:11:22:33:44:50, vmb, two

--- a/racker-sim/qemu-wrap
+++ b/racker-sim/qemu-wrap
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+QEMU_ARGS="${QEMU_ARGS-"-nographic"}"
+
+ID="$1"
+PRIMARY="$2"
+BMC="$3"
+SEC="$4"
+TAP0="$5"
+TAP1="$6"
+IMAGE="$7"
+BOOT="$8"
+
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+
+QEMU_PID="9999999999999999"
+
+function cancel() {
+  echo
+  echo "Terminating QEMU PID ${QEMU_PID}"
+  kill "${QEMU_PID}"
+  exit 1
+}
+trap cancel INT
+
+if [ "$BOOT" = pxe ]; then
+  ARG="order=n,strict=on"
+else
+  # none/default/disk
+  ARG="order=c,strict=on"
+fi
+
+if [ "${ID}" != 1 ]; then
+  DISK2_ARGS="-drive if=virtio,file=${IMAGE}.disk2"
+  MEMORY=2500
+else
+  DISK2_ARGS=""
+  MEMORY=1000
+fi
+
+state="/tmp/ipmi-sim/${ID}"
+mkdir -p "${state}"
+echo "$$" > "${state}/pid"
+
+set +e
+qemu-system-x86_64 -name "node${ID}" -m "${MEMORY}" -netdev "tap,id=eth0,ifname=${TAP0},script=no,downscript=no" -device "virtio-net-pci,netdev=eth0,mac=${PRIMARY}" -netdev "tap,id=eth1,ifname=${TAP1},script=no,downscript=no" -device "virtio-net-pci,netdev=eth1,mac=${SEC}" -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 -drive "if=virtio,file=${IMAGE}" -machine accel=kvm -cpu host -smp 4 -chardev "socket,id=ipmichr0,host=localhost,port=90${ID}2,reconnect=10" -device ipmi-bmc-extern,chardev=ipmichr0,id=bmc0 -device isa-ipmi-bt,bmc=bmc0,irq=0 -serial "mon:tcp::90${ID}3,server,telnet,nowait" -boot "${ARG}" -no-reboot ${DISK2_ARGS} ${QEMU_ARGS} > /dev/stderr &
+QEMU_PID="$!"
+set -e
+echo "Watching over QEMU PID ${QEMU_PID} for VM ${ID}" > /dev/stderr
+# Run QEMU in background to be able to kill it by forwarding TERM
+while [ -e "${state}/pid" ] && [ -e "/proc/${QEMU_PID}/" ]; do
+  sleep 0.5
+done
+if [ -e "/proc/${QEMU_PID}/" ]; then
+  kill "${QEMU_PID}"
+  echo "Permanent power off for VM ${ID}" > /dev/stderr
+  exit 0
+else
+  echo "Rebooting VM ${ID} after guest shutdown or reboot (Permanent power off only via IPMI)" > /dev/stderr
+fi
+# Restart VM again as workaround because the boot order can't be changed while QEMU is running.
+# This means permanent power off is only supported through IPMI shutdown which kills this script.
+rm -f "${state}/pid" 2>/dev/null
+exec "${SCRIPTFOLDER}/chassis" "${ID}" "${PRIMARY}" "${BMC}" "${SEC}" "${TAP0}" "${TAP1}" "${IMAGE}" set power 1


### PR DESCRIPTION
To test Racker without a special hardware we need a QEMU test
    environment which sets up an IPMI emulator.
    Add a script to configure and run ipmi_sim and add the plumbing for
    QEMU VM management. Only the functionality Racker needs is tested.
    It behaves like an IPMI-compatible rack with a TOR switch for the
    public network on the secondary NICs and a second switch for the
    rack-internal network for the primary NICs and the BMCs. The management
    node has swapped cables so that the primary NIC and BMC is on the
    public network and the secondary NIC can manage the rack-internal
    network for DHCP/PXE.
    The script creates two bridges, the public one with NAT for the TAP
    devices for the secondary NIC, the internal one without NAT for the
    TAP devices of the primary NIC and the BMC veth devices. The BMC veth
    pair has one part moved to a new network namespace where dhclient runs
    for the DHCP configuration of the BMC IP address. Because dhclient is
    potentially modifying the root filesystem, a mount namespace is also
    created with an overlayfs to protect the real /etc/resolv.conf.
