### PR TITLE
installer/racker: fix wrong prompt name

### DIFF
--- a/installer/racker
+++ b/installer/racker
@@ -208,7 +208,7 @@ elif [ "$1" = bootstrap ]; then
   if [ ! -n "${ha_node_types}" ]; then
     # We have no HA nodes available, so let's not prompt about that and skip
     # directly into the simple nodes choosing
-    first_cluster_type_prompt="controller-type-simple"
+    first_cluster_type_prompt="controller-type"
   else
     ha_node_types=$(echo -n "${ha_node_types}"|sed 's/$/\\/g' | tr '\n' n | sed 's/\\$//g')
     default_num_controllers=3


### PR DESCRIPTION
The wizard stopped working when less then three nodes of the same type
where available because a wrong prompt label was chosen.
Use the correct prompt label.

## Testing done

Tested with two nodes in https://github.com/kinvolk/racker/pull/87