### PR TITLE
bootstrap: recreate node when PXE boot is forced with plain QEMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,34 @@ To upgrade to the latest version which may have breaking changes, run `racker up
 
 Both will update the `lokoctl` and `terraform` binaries, too.
 
+### Lokomotive Baremetal Development Environment
+
+The part of Racker which creates the Lokomotive configuration can be run stand-alone to set up libvirt QEMU instances on your laptop.
+This is different from the [IPMI QEMU simulator environment](racker-sim/) which is preferred as it fully utilizes Racker.
+However, for quick development of Racker/Lokomotive this is how to run it:
+
+```
+cd /var/tmp/
+mkdir mycluster # "prepare.sh create" must run in an empty folder with just the controller_macs/worker_macs files
+cd mycluster
+echo 0c:42:a1:11:11:11 > controller_macs
+echo 0c:42:a1:11:11:22 > worker_macs
+# compile the right Lokomotive branch used in Racker (see installer/conf.yaml)
+sudo rm -r /opt/racker/terraform/
+sudo mkdir -p /opt/racker/terraform
+sudo cp -r /home/$USER/kinvolk/lokomotive/assets/terraform-modules/matchbox-flatcar/* /opt/racker/terraform
+PATH="$PATH:/home/$USER/kinvolk/lokomotive" /home/$USER/kinvolk/racker/bootstrap/prepare.sh create
+[…]
+PATH="$PATH:/home/$USER/kinvolk/lokomotive" lokoctl cluster apply # or any other things you want to do
+[…]
+# later destroy it again:
+PATH="$PATH:/home/$USER/kinvolk/lokomotive" /home/$USER/kinvolk/racker/bootstrap/prepare.sh destroy
+```
+
+It will create two bridges, one for the internal PXE and one for the network with Internet access (using NAT).
+Matchbox and dnsmasq are started as containers (when using Podman matchbox is a user container and dnsmasq a root container).
+The `/opt/racker-state/` folder gets populated with the Flatcar image and the Matchbox configuration.
+
 ## Code of Conduct
 
 Please refer to the Kinvolk [Code of Conduct](https://github.com/kinvolk/contribution/blob/master/CODE_OF_CONDUCT.md).

--- a/bootstrap/prepare.sh
+++ b/bootstrap/prepare.sh
@@ -630,7 +630,7 @@ EOF
     tee -a "${variable_file}" >/dev/null <<-EOF
 	kernel_console = []
 	install_pre_reboot_cmds = ""
-	pxe_commands = "sudo virt-install --name \$domain --network=bridge:${INTERNAL_BRIDGE_NAME},mac=\$mac  --network=bridge:${EXTERNAL_BRIDGE_NAME} --memory=${VM_MEMORY} --vcpus=1 --disk pool=default,size=${VM_DISK} --os-type=linux --os-variant=generic --noautoconsole --events on_poweroff=preserve --boot=hd,network"
+	pxe_commands = "sudo virsh destroy \$domain || true; sudo virsh undefine \$domain || true; sudo virsh pool-refresh default || true; sudo virsh vol-delete --pool default \$domain.qcow2 || true; sudo virt-install --name \$domain --network=bridge:${INTERNAL_BRIDGE_NAME},mac=\$mac  --network=bridge:${EXTERNAL_BRIDGE_NAME} --memory=${VM_MEMORY} --vcpus=1 --disk pool=default,size=${VM_DISK} --os-type=linux --os-variant=generic --noautoconsole --events on_poweroff=preserve --boot=hd,network"
 EOF
   else
     # The first ipmitool raw command is used to disable the 60 secs timeout that clears the boot flag

--- a/bootstrap/prepare.sh
+++ b/bootstrap/prepare.sh
@@ -523,7 +523,11 @@ function gen_cluster_vars() {
     name="controller"
   fi
   for mac in ${MAC_ADDRESS_LIST[*]}; do
-    node_color="$(echo "$NODES" | grep ${mac} | cut -d , -f 4 | xargs)"
+    if [ -n "$USE_QEMU" ]; then
+      node_color=""
+    else
+      node_color="$(echo "$NODES" | grep ${mac} | cut -d , -f 4 | xargs)"
+    fi
     ip_address="$(calc_ip_addr $mac)"
     if [ "$type" = "lokomotive" ]; then
       id="${CLUSTER_NAME}-${name}-${count}.${KUBERNETES_DOMAIN_NAME}"


### PR DESCRIPTION
In the QEMU mode where the prepare.sh script is directly used (i.e.,
not the Racker QEMU IPMI simulator environment), the reprovisioning
with PXE could be only forced when the VM got deleted manually before.
Automatically delete any existing VM before creating it.

Fixes https://github.com/kinvolk/racker/issues/42


## How to use

```
cd /var/tmp/
mkdir mycluster # prepare.sh create must run in an empty folder with just the *_macs files
cd mycluster
echo 0c:42:a1:11:11:11 > controller_macs
echo 0c:42:a1:11:11:22 > worker_macs
sudo rm -r /opt/racker/terraform/
sudo mkdir -p /opt/racker/terraform
sudo cp -r /home/$USER/kinvolk/lokomotive/assets/terraform-modules/matchbox-flatcar/* /opt/racker/terraform
# compile the right Lokomotive branch used in Racker
PATH="$PATH:/home/$USER/kinvolk/lokomotive" /home/$USER/kinvolk/racker/bootstrap/prepare.sh create
[…]
PATH="$PATH:/home/$USER/kinvolk/lokomotive" /home/$USER/kinvolk/racker/bootstrap/prepare.sh destroy
```

## Testing done

```
rm lokoctl-assets/cluster-assets/0c:42:a1:11:11:22 # force a PXE installation when reprovisioning
nano cl/lokomotive-worker-0.k8s.localdomain.yaml # change something in /etc/hosts to force a reprovisioning
PATH="$PATH:/home/$USER/kinvolk/lokomotive" lokoctl cluster apply
```