### PR TITLE
Use latest Lokomotive, jump to Racker 0.2

### DIFF
--- a/bootstrap/baremetal.lokocfg
+++ b/bootstrap/baremetal.lokocfg
@@ -24,6 +24,7 @@ cluster "bare-metal" {
   pxe_commands = var.pxe_commands
   install_pre_reboot_cmds = var.install_pre_reboot_cmds
   node_specific_labels = var.node_specific_labels
+  wipe_additional_disks = true
 
   # Adds oidc flags to API server with default values.
   # Acts as a smoke test to check if API server is functional after addition

--- a/installer/conf.yaml
+++ b/installer/conf.yaml
@@ -1,4 +1,4 @@
-version: 0.1
+version: 0.2
 modules:
   - name: .
     assets:
@@ -24,7 +24,7 @@ modules:
       dest-filename: kubectl
     - type: git
       url: https://github.com/kinvolk/lokomotive.git
-      branch: "imran/baremetal-reprovisioning"
+      branch: "master"
     build-commands:
     - mkdir bin
     - cd ./wizard && go build -o args-wizard ./args-wizard.go && mv ./args-wizard ../bin/ && cd .. && rm -rf ./wizard


### PR DESCRIPTION
Users should follow the update guides when updating from Racker 0.1:
      https://github.com/kinvolk/lokomotive/releases/tag/v0.7.0
      https://github.com/kinvolk/lokomotive/releases/tag/v0.8.0
    because there can be a few breaking changes depending on the components
    used.
    Users also should add `wipe_additional_disks = true` to their
    baremetal.lokocfg file.


## How to use

Run `racker get THISIMAGE` and run `lokoctl cluster apply -v` and follow the steps above

## Testing done

Works with a simple racker-sim cluster, the update script probably should be limited to the controller because changing the worker shouldn't be needed as it is recreated.