### PR TITLE
racker 0.3: new release for Lokomotive 0.9

### DIFF
--- a/bootstrap/baremetal.lokocfg
+++ b/bootstrap/baremetal.lokocfg
@@ -25,6 +25,9 @@ cluster "bare-metal" {
   install_pre_reboot_cmds = var.install_pre_reboot_cmds
   node_specific_labels = var.node_specific_labels
   wipe_additional_disks = true
+  # Change this to 'true' to prevent the worker from being reprovisioned due to configuration changes.
+  # Using 'true' means the worker keeps its current state (e.g., storage volumes) but things like new SSH keys need to be added manually.
+  ignore_worker_changes = false
 
   # Adds oidc flags to API server with default values.
   # Acts as a smoke test to check if API server is functional after addition

--- a/bootstrap/ipmi
+++ b/bootstrap/ipmi
@@ -97,6 +97,8 @@ fi
 IPMI_USER=$(cat /usr/share/oem/ipmi_user)
 IPMI_PASSWORD=$(cat /usr/share/oem/ipmi_password)
 if [ "${CMD}" = "sol activate" ]; then
+  # Disconnect any dangling sessions
+  docker run --privileged --net host --rm ${ARGS} quay.io/kinvolk/racker:${RACKER_VERSION} ipmitool -C3 -I lanplus -H "${IP_ADDR}" -U "${IPMI_USER}" -P "${IPMI_PASSWORD}" sol deactivate || true
   echo "Opening serial console, detach with ~~. (double ~ because you need to escape the ~ when already using SSH or a serial console, with two SSH connections it would be ~~~.)"
 fi
 if [ "${CMD}" = "diag" ]; then

--- a/docs/usage/after_provisioning.md
+++ b/docs/usage/after_provisioning.md
@@ -92,6 +92,16 @@ Now apply the change which is done by a full reprovisioning including a PXE boot
 lokoctl cluster apply
 ```
 
+### Keeping worker node state by preventing reprovisioning
+
+While Racker has the default behavior to reprovision the worker nodes on configuration changes, this can cause disruption and loss of data in the storage volumes.
+You can opt out of this behavior by changing the value of `ignore_worker_changes` in `baremetal.lokocfg`.
+
+```
+vi baremetal.lokocfg
+# now change "ignore_worker_changes = false" to "ignore_worker_changes = true"
+```
+
 ### Excluding a node
 
 A faulty node may prevent a change operation to be completed. The node can be removed from the cluster configuration like done during the bootstrap.

--- a/docs/usage/updating.md
+++ b/docs/usage/updating.md
@@ -25,6 +25,28 @@ The `racker upgrade` on the other hand, will pull whatever the latest tag for Ra
 **Important:** This means that running `racker upgrade` can bring new versions of tools/modules (`lokoctl`, `terraform`, etc.) that may be incompatible with the ones currently deployed (which means that e.g. the Lokomotive configuration may have to be manually updated to fit the new version of `lokoctl`).
 For this reason, upgrading Racker should be done only when no cluster is yet deployed, or when the cluster has been wiped out and the intent is to start over with the very latest Racker version.
 
+## Notes for upgrading to Racker 0.3
+
+The jump from Racker 0.2 to 0.3 through `racker upgrade` requires to add the following entry to the `baremetal.lokocfg` file to keep the behavior of reprovisioning worker nodes on configuration changes:
+
+```
+ignore_worker_changes = false
+```
+
+The Racker 0.3 release is using Lokomotive v0.9.0 with no modifications as all Racker changes are now upstreamed.
+The [release notes of Lokomotive v0.9.0](https://github.com/kinvolk/lokomotive/releases/tag/v0.9.0) are valid except for the update steps for the Baremetal platform which are reduced to the change mentioned above.
+
+After changing the `baremetal.lokocfg` file as metioned, run the following steps:
+
+```
+racker upgrade
+lokoctl cluster apply --skip-components
+curl -LO https://github.com/kinvolk/lokomotive/archive/v0.9.0.tar.gz
+tar -xvzf v0.9.0.tar.gz
+./lokomotive-0.9.0/scripts/update/0.8.0-0.9.0/update.sh
+lokoctl components apply
+```
+
 # Upgrading / downgrading to a particular version
 
 Sometimes it is important to fetch a particular version of Racker. For example, if an update has an important bug, or an *upgrade* has been mistakenly run, it is useful to have a way to go back to a particular version of Racker.

--- a/installer/conf.yaml
+++ b/installer/conf.yaml
@@ -1,4 +1,4 @@
-version: 0.2
+version: 0.3
 modules:
   - name: .
     assets:
@@ -24,7 +24,7 @@ modules:
       dest-filename: kubectl
     - type: git
       url: https://github.com/kinvolk/lokomotive.git
-      branch: "master"
+      branch: "v0.9.0"
     build-commands:
     - mkdir bin
     - cd ./wizard && go build -o args-wizard ./args-wizard.go && mv ./args-wizard ../bin/ && cd .. && rm -rf ./wizard


### PR DESCRIPTION
This release contains the latest changes brought by the 0.9 Lokomotive
    release.
Racker 0.3 now comes with the `lokoctl` binary that has
    `azure-arc-onboarding` component for easy onboarding of a Lokomotive
    cluster on Azure Arc. It also allows to configure whether a worker node
    should be reprovisioned or not on configurations changes.

Done: when merging, create a tag and a release which includes the PDF.